### PR TITLE
Fixing a makefile issue appearing during 'make check' command on arch distro (CachyOS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,11 @@ GL_RUNTIME_ARTIFACTS := \
 	build/lib/x86_64-linux-gnu/libframe_pacer_gl.so \
 	build/lib/i386-linux-gnu/libframe_pacer_gl.so \
 	build/lib/x86_64-linux-gnu/libframe_pacer_gl_shim.so \
-	build/lib/i386-linux-gnu/libframe_pacer_gl_shim.so
+	build/lib/i386-linux-gnu/libframe_pacer_gl_shim.so \
+	build/lib/libframe_pacer_gl.so \
+	build/lib32/libframe_pacer_gl.so \
+	build/lib/libframe_pacer_gl_shim.so \
+	build/lib32/libframe_pacer_gl_shim.so
 
 .PHONY: all check check-unit check-unit-i386 check-shell check-docs check-hud-image check-abi check-analyzer check-sanitize check-tsan check-coverage docs-hud-image \
 	clean install uninstall thread-cpu-quota-probe run-thread-cpu-quota-probe \
@@ -205,6 +209,12 @@ build/lib/x86_64-linux-gnu/%.so: build/x86_64/%.so
 	mkdir -p $(@D)
 	cp $< $@
 build/lib/i386-linux-gnu/%.so: build/i386/%.so
+	mkdir -p $(@D)
+	cp $< $@
+build/lib/%.so: build/x86_64/%.so
+	mkdir -p $(@D)
+	cp $< $@
+build/lib32/%.so: build/i386/%.so
 	mkdir -p $(@D)
 	cp $< $@
 build/x86_64/libGL.so.1: tests/gl_swap_provider.c


### PR DESCRIPTION
Fixes the error appearing on arch linux distros when running `make check` command.

The error:

> make[1]: Leaving directory '<path_to_frame_pacer_install_dir>'
> sh ./tests/test_gl_pacer.sh
> ERROR: ld.so: object '<path_to_frame_pacer_install_dir>/build/${LIB}/libframe_pacer_gl_shim.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
> ERROR: ld.so: object '<path_to_frame_pacer_install_dir>/build/${LIB}/libframe_pacer_gl_shim.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
> test-gl-pacer: tests/test_gl_pacer.c:38: main: Assertion `symbol' failed.
> ./tests/test_gl_pacer.sh: line 33: 21434 Aborted                    (core dumped) XDG_CONFIG_HOME="$state" XDG_STATE_HOME="$state" LD_LIBRARY_PATH="$root/build/$arch" FRAME_PACER_LOG=1 LD_PRELOAD="$root/build/\${LIB}/libframe_pacer_gl_shim.so" "$test_program"
> make: *** [Makefile:490: check] Error 134