### PR TITLE
fix: Identify repository during release publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,5 +101,6 @@ jobs:
           prerelease=
           case "$version" in *-*) prerelease=--prerelease ;; esac
           gh release create "$GITHUB_REF_NAME" "$archive" "$checksum" \
+            --repo "$GITHUB_REPOSITORY" \
             --verify-tag --generate-notes --notes-file "$notes" \
             --title "frame-pacer $version" $prerelease

--- a/tests/check_workflows.py
+++ b/tests/check_workflows.py
@@ -105,6 +105,10 @@ def validate_release(workflow: dict) -> None:
                for step in jobs["build"].get("steps", [])) == 1
     assert sum(step.get("uses", "").startswith("actions/download-artifact@")
                for step in publish_steps) == 1
+    publish_scripts = [step.get("run", "") for step in publish_steps if step.get("run")]
+    assert any('--repo "$GITHUB_REPOSITORY"' in script for script in publish_scripts), (
+        "Release publication must identify the repository without a checkout"
+    )
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

- pass the explicit GitHub repository to the checkout-free publish job
- add a workflow validation guard for this requirement

## Why

The release build and artifact transfer succeeded for `v0.1.0-beta.1`, but the publication job could not discover a Git repository because it intentionally performs no checkout.

## Validation

- `make check-workflows`
- `make check-shell`
- `git diff --check`